### PR TITLE
Emit end and error events

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,8 +23,14 @@ function tapeIstanbul (output) {
 
     function writeFile (coverage) {
       promiseify(fs.writeFile)(output || 'coverage.json', JSON.stringify(coverage, null, 2))
-        .then(resolve)
-        .catch(reject)
+        .then(function (results) {
+          pause.emit('end')
+          resolve(results)
+        })
+        .catch(function (err) {
+          pause.emit('error', err)
+          reject(err)
+        })
     }
   })
 

--- a/test.js
+++ b/test.js
@@ -12,14 +12,16 @@ const tapeIstanbul = require('./')
 const tapOutput = fs.readFileSync('fixture-output.txt', 'utf8')
 
 test('api', function (t) {
-  t.plan(3)
+  t.plan(4)
 
   browserify()
     .add(path.resolve(__dirname, 'fixture-test.js'))
     .plugin(path.resolve(__dirname, 'plugin.js'))
     .bundle()
     .pipe(node())
-    .pipe(tapeIstanbul())
+    .pipe(tapeIstanbul().on('end', function () {
+      t.ok(true, 'end was emitted')
+    }))
     .pipe(concat(function (output) {
       t.equal(output.toString(), tapOutput, 'passes tap output through')
       const coverageFile = fs.readFileSync('coverage.json')


### PR DESCRIPTION
When using this programatically, it is helpful to be able to detect when the
report has finished writing to disk so you can have instanbul generate
a report from it. The pumpify isntance returned doesn't emit `end` nor `error`
so I had it happen in the promise resolution functions.