### PR TITLE
use carpetify

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "browserify": "~13.1.0",
-    "browserify-istanbul": "~2.0.0",
+    "carpetify": "^1.0.0",
     "duplexify": "~3.5.0",
     "standard": "^8.0.0",
     "tape": "^4.0.0"

--- a/plugin.js
+++ b/plugin.js
@@ -8,5 +8,5 @@ function tapeIstanbulify (browserify, opts) {
   opts = opts || {}
   browserify
     .add(path.resolve(__dirname, 'hook.js'))
-    .transform('browserify-istanbul', opts)
+    .transform('carpetify', opts)
 }


### PR DESCRIPTION
Hi!

So I was getting some gruff with using browserify-istanbul: tt would frequently print `undefined:0` when it was printing coverage because no coverage had been recorded.

That repo seems to be unmaintained given the length of time PRs have been open plus the lack of response on my original PR to there.

So I forked it and applied the PR to update to the latest version of istanbul-lib-instrument (https://github.com/devongovett/browserify-istanbul/pull/40).

Not sure if this in the cards, but figured I'd propose it!